### PR TITLE
Autoscale Font Size Depending on Message Length

### DIFF
--- a/script.js
+++ b/script.js
@@ -53,8 +53,12 @@ var greenScreen = new Vue({
     fontSize: function (newFontSize) {
       this.resetFontScale()
     },
-    message: function (newMessage) {
-      this.updateFontScale()
+    message: function (newMessage, oldMessage) {
+      var messageCleared = newMessage.trim().length === 0
+
+      messageCleared
+        ? this.resetFontScale()
+        : this.updateFontScale()
     }
   }
 })

--- a/script.js
+++ b/script.js
@@ -44,7 +44,9 @@ var greenScreen = new Vue({
       var $message = document.getElementById('message')
       var overflowed = $message.scrollWidth > $message.clientWidth
 
-      if (overflowed) this.$set(this, 'fontScale', this.fontScale - scaleSpeed)
+      if (overflowed) {
+        this.$set(this, 'fontScale', this.fontScale * (1 - scaleSpeed))
+      }
     }
   },
   watch: {

--- a/script.js
+++ b/script.js
@@ -8,6 +8,9 @@ var greenScreen = new Vue({
     valign: 'middle'
   },
   computed: {
+    scaledFontSize: function () {
+      return this.fontSize * this.fontScale
+    },
     messageStyle: function () {
       var fontFamily = {
         'monospace': "'VT323', monospace",
@@ -15,11 +18,9 @@ var greenScreen = new Vue({
         'serif': "'Droid Serif', serif"
       }[this.fontFamily]
 
-      var scaledFontSize = this.fontSize * this.fontScale
-
       return {
         fontFamily,
-        fontSize: `${scaledFontSize}px`
+        fontSize: `${this.scaledFontSize}px`
       }
     },
     wrapperStyle: function () {
@@ -34,12 +35,24 @@ var greenScreen = new Vue({
       }
     }
   },
-  watch: {
-    message: function (newMessage) {
+  methods: {
+    resetFontScale: function () {
+      this.$set(this, 'fontScale', 1)
+    },
+    updateFontScale: function () {
+      var scaleSpeed = 0.10
       var $message = document.getElementById('message')
       var overflowed = $message.scrollWidth > $message.clientWidth
 
-      if (overflowed) this.$set(this, 'fontScale', this.fontScale - 0.1)
+      if (overflowed) this.$set(this, 'fontScale', this.fontScale - scaleSpeed)
+    }
+  },
+  watch: {
+    fontSize: function (newFontSize) {
+      this.resetFontScale()
+    },
+    message: function (newMessage) {
+      this.updateFontScale()
     }
   }
 })

--- a/script.js
+++ b/script.js
@@ -2,6 +2,7 @@ var greenScreen = new Vue({
   el: '#greenScreen',
   data: {
     fontFamily: 'monospace',
+    fontScale: 1,
     fontSize: '96',
     message: 'Greenscreen',
     valign: 'middle'
@@ -14,9 +15,11 @@ var greenScreen = new Vue({
         'serif': "'Droid Serif', serif"
       }[this.fontFamily]
 
+      var scaledFontSize = this.fontSize * this.fontScale
+
       return {
         fontFamily,
-        fontSize: `${this.fontSize}px`
+        fontSize: `${scaledFontSize}px`
       }
     },
     wrapperStyle: function () {
@@ -29,6 +32,14 @@ var greenScreen = new Vue({
       return {
         justifyContent
       }
+    }
+  },
+  watch: {
+    message: function (newMessage) {
+      var $message = document.getElementById('message')
+      var overflowed = $message.scrollWidth > $message.clientWidth
+
+      if (overflowed) this.$set(this, 'fontScale', this.fontScale - 0.1)
     }
   }
 })

--- a/style.css
+++ b/style.css
@@ -21,14 +21,14 @@ body {
   flex-direction: column;
   flex: 1;
   font-size: 16pt;
+  align-items: center;
 }
 
 #message {
-  overflow: hidden;
   padding: 25px 0;
   text-align: center;
   white-space: nowrap;
-  width: 100%;
+  width: 90%;
 }
 
 #inputs {

--- a/style.css
+++ b/style.css
@@ -24,8 +24,10 @@ body {
 }
 
 #message {
+  overflow: hidden;
   padding: 25px 0;
   text-align: center;
+  white-space: nowrap;
   width: 100%;
 }
 


### PR DESCRIPTION
In order to allow for an arbitrary amount of message text to appear on a single line, auto-scale the font size depending on the message length.

 * [x] Messages should be confined to a single line
 * [x] When the content of the message exceeds the width of the container, scale the font size
 * [x] When the font-size dropdown changes, or the message is cleared out, reset the scale
 * [x] Ensure message is not cut off while shrinking
